### PR TITLE
Remove scroll bars on Kanban cards

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -4935,6 +4935,11 @@ body.plugin-sliding-panes-rotate-header
                 Kanban
 ────────────────────────────────────*/
 
+/* remove scroll bar on cards */
+.kanban-plugin__markdown-preview-view > div > * {
+  overflow: hidden;
+}
+
 .view-content .kanban-plugin {
     background: var(--background-primary);
 }


### PR DESCRIPTION
## To Reproduce
- Open a new Kanban board
- Create a new card with bullet points
    - corresponding markdown: `- [ ] Test<br>-Test bullet 1`
- A scroll bar will appear even though there is no content to be scrolled down to

This PR removes the unnecessary scroll bars on Kanban cards by setting the `overflow` to `hidden`.