### PR TITLE
Fixing the suggestion-flair icon for i.a. Aliases

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -4462,6 +4462,11 @@ input.prompt-input {
     border-radius: var(--scale-2-1);
 }
 
+.suggestion-container .suggestion-flair {
+    position: unset;
+    margin-right: 5px;
+}
+
 .suggestion-item.search-suggest-item.list-item.mod-group {
     color: var(--color-gray-10);
     padding:    var(--scale-2-2)


### PR DESCRIPTION
The suggestion-flair was styled with a position top:5px and left:6px. This was making the icon of aliases flow behind the alias text. I created an issue for this (Issue #34), but it annoyed me too much, so I decided to fix it myself.

I did not remove the original `.suggestion-flair` styling because I am unsure if this is being used anywhere else.

<img width="577" alt="Screenshot 2022-05-15 at 10 48 17" src="https://user-images.githubusercontent.com/17490821/168465099-ba5530af-8dbb-453e-8a83-ab94e9486103.png">
